### PR TITLE
Fix a Lua error if a more recent version is available

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -2479,6 +2479,7 @@ function Comms:TellGuildMemberItsTimeToUpdate(targetGUID)
     self:Transmit(update, "WHISPER", targetGUID, "NORMAL")
 end
 
+Comms.versionsChecked = {}
 
 function Comms:OnUpdateMessage(data)
     if type(data.payload.version) == "number" then


### PR DESCRIPTION
`Comms.versionsChecked` is indexed by `Comms:OnUpdateMessage` and `Comms:OnCharacterOnline`, but is not actually defined to be a table anywhere.

The result is a Lua error that occurs every time an update notification is received.