### PR TITLE
Do not append main character's name if the tooltip unit has changed

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -3164,7 +3164,11 @@ function Guildbook:Init()
                     local main = Guildbook:GetCharacterFromCache(character.MainCharacter)
                     if main then
                         C_Timer.After(0.1, function()
-                            self:AppendText(" ["..Guildbook.Colours[main.Class]:WrapTextInColorCode(main.Name).."]")
+                            -- Make sure the tooltip unit hasn't changed
+                            local _, currentUnit = self:GetUnit()
+                            if currentUnit and (UnitGUID(currentUnit) == guid) then
+                                self:AppendText(" ["..Guildbook.Colours[main.Class]:WrapTextInColorCode(main.Name).."]")
+                            end
                         end)
                     end
                 end


### PR DESCRIPTION
The logic that appends the main character's name to the GameTooltip contains a 0.1 second delay. Currently, if the cursor moves to something unrelated in this time, the name will be appended regardless. This can result in strange tooltips, such as `Meeting Stone [Treeston]`.

This PR adds a check to the delay callback, making sure that the tooltip unit is still the same that it originally was.