### PR TITLE
Enable static GETGLOBAL analysis by upvalue-ing all used APIs

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,2 @@
+ignore:
+    - globals.lua

--- a/Core.lua
+++ b/Core.lua
@@ -20,6 +20,32 @@ the copyright holders.
 
 ]==]--
 
+-- GLOBALS: GUILDBOOK_GLOBAL, GUILDBOOK_CHARACTER, GUILDBOOK_TSDB, GuildbookUI, GuildbookMixin
+
+local _G, string, tostring, strsplit, tonumber, next, pairs, ipairs, table, date, time, type, select, print, math, wipe, hooksecurefunc =
+      _G, string, tostring, strsplit, tonumber, next, pairs, ipairs, table, date, time, type, select, print, math, wipe, hooksecurefunc
+local C_Timer, C_PlayerInfo, C_CreatureInfo, C_LFGList, C_GuildInfo, PlayerLocation, Spell, Item =
+      C_Timer, C_PlayerInfo, C_CreatureInfo, C_LFGList, C_GuildInfo, PlayerLocation, Spell, Item
+local UnitGUID, UnitName, GetTime, GetServerTime, GetPlayerInfoByGUID, Ambiguate, GetNumGuildMembers, GetGuildRosterInfo, IsInInstance, InCombatLockdown, GetTalentInfo, GetTalentLink =
+      UnitGUID, UnitName, GetTime, GetServerTime, GetPlayerInfoByGUID, Ambiguate, GetNumGuildMembers, GetGuildRosterInfo, IsInInstance, InCombatLockdown, GetTalentInfo, GetTalentLink
+local GetNumTalentTabs, GetTalentTabInfo, SecondsToTime, GetSpellInfo, GetSpellLink, GetContainerNumSlots, GetContainerItemInfo, GetItemInfoInstant, GetNormalizedRealmName, GetMoney, GuildRoster =
+      GetNumTalentTabs, GetTalentTabInfo, SecondsToTime, GetSpellInfo, GetSpellLink, GetContainerNumSlots, GetContainerItemInfo, GetItemInfoInstant, GetNormalizedRealmName, GetMoney, GuildRoster
+local ChatFrame_AddMessageEventFilter, ChatFrame_RemoveMessageEventFilter, CallbackRegistryMixin, GetRangedCritChance, GetCritChance, GetHaste, GetManaRegen, GetSpellCritChance, GetSpellBonusDamage = 
+      ChatFrame_AddMessageEventFilter, ChatFrame_RemoveMessageEventFilter, CallbackRegistryMixin, GetRangedCritChance, GetCritChance, GetHaste, GetManaRegen, GetSpellCritChance, GetSpellBonusDamage
+local GetSpellHitModifier, GetCombatRatingBonus, GetHitModifier, GetExpertise, GetDodgeChance, GetParryChance, GetShieldBlock, GetBlockChance, UnitArmor, UnitDefense, GetNumSkillLines, GetSkillLineInfo = 
+      GetSpellHitModifier, GetCombatRatingBonus, GetHitModifier, GetExpertise, GetDodgeChance, GetParryChance, GetShieldBlock, GetBlockChance, UnitArmor, UnitDefense, GetNumSkillLines, GetSkillLineInfo
+local LibStub, GameTooltip, CreateFrame, GetGuildInfo, IsInGuild, UIParent, GetItemInfo, GetNumTalents, GuildControlGetNumRanks, GuildControlGetRankName, CreateAtlasMarkup =
+      LibStub, GameTooltip, CreateFrame, GetGuildInfo, IsInGuild, UIParent, GetItemInfo, GetNumTalents, GuildControlGetNumRanks, GuildControlGetRankName, CreateAtlasMarkup
+local GetAddOnMetadata, GetSpellBonusHealing, UnitDamage, UnitAttackSpeed, UnitRangedDamage, UnitAttackPower, UnitStat, StaticPopup_Show, InterfaceOptionsFrame, InterfaceOptionsFrame_OpenToCategory =
+      GetAddOnMetadata, GetSpellBonusHealing, UnitDamage, UnitAttackSpeed, UnitRangedDamage, UnitAttackPower, UnitStat, StaticPopup_Show, InterfaceOptionsFrame, InterfaceOptionsFrame_OpenToCategory
+local CraftFrameTitleText, GetCraftSkillLine, GetNumCrafts, GetCraftInfo, GetCraftNumReagents, GetCraftReagentInfo, GetCraftReagentItemLink, CraftRankFrameSkillRank, GetNumSavedInstances =
+      CraftFrameTitleText, GetCraftSkillLine, GetNumCrafts, GetCraftInfo, GetCraftNumReagents, GetCraftReagentInfo, GetCraftReagentItemLink, CraftRankFrameSkillRank, GetNumSavedInstances
+local GetSavedInstanceInfo, GetInventoryItemLink, GetInventorySlotInfo, GetSpellTabInfo, GetSpellBookItemInfo, GetTradeSkillLine, TradeSkillFrameTitleText, TradeSkillRankFrameSkillRank, GetNumTradeSkills =
+      GetSavedInstanceInfo, GetInventoryItemLink, GetInventorySlotInfo, GetSpellTabInfo, GetSpellBookItemInfo, GetTradeSkillLine, TradeSkillFrameTitleText, TradeSkillRankFrameSkillRank, GetNumTradeSkills
+local GetTradeSkillInfo, GetTradeSkillItemLink, GetTradeSkillNumReagents, GetTradeSkillReagentInfo, GetTradeSkillReagentItemLink, ToggleFriendsFrame, GameTooltip_SetDefaultAnchor =
+      GetTradeSkillInfo, GetTradeSkillItemLink, GetTradeSkillNumReagents, GetTradeSkillReagentInfo, GetTradeSkillReagentItemLink, ToggleFriendsFrame, GameTooltip_SetDefaultAnchor
+local ERR_FRIEND_OFFLINE_S, ERR_FRIEND_ONLINE_SS, ERR_GUILD_JOIN_S, BOOKTYPE_SPELL, WOW_PROJECT_ID, WOW_PROJECT_CLASSIC, WOW_PROJECT_BURNING_CRUSADE_CLASSIC, CR_HIT_SPELL, CR_HIT_MELEE, CR_HIT_RANGED =
+      ERR_FRIEND_OFFLINE_S, ERR_FRIEND_ONLINE_SS, ERR_GUILD_JOIN_S, BOOKTYPE_SPELL, WOW_PROJECT_ID, WOW_PROJECT_CLASSIC, WOW_PROJECT_BURNING_CRUSADE_CLASSIC, CR_HIT_SPELL, CR_HIT_MELEE, CR_HIT_RANGED
 
 local addonName, Guildbook = ...
 

--- a/Core.lua
+++ b/Core.lua
@@ -1053,7 +1053,7 @@ function Roster:OnChatMessageSystem(...)
     if msg:find(loggedOut) then
         local characterName, _ = strsplit(" ", msg)
 
-        GuildbookUI.home:OnNewsFeedReceived(_, {
+        GuildbookUI.home:OnNewsFeedReceived(nil, {
             newsType = "logout",
             text = string.format("%s has gone offline", characterName)
         })
@@ -1073,7 +1073,7 @@ function Roster:OnChatMessageSystem(...)
         local s, e = name:find("%["), name:find("%]")
         local characterName = name:sub(s+1, e-1)
 
-        GuildbookUI.home:OnNewsFeedReceived(_, {
+        GuildbookUI.home:OnNewsFeedReceived(nil, {
             newsType = "login",
             text = string.format("%s has come online", characterName)
         })
@@ -1091,7 +1091,7 @@ function Roster:OnChatMessageSystem(...)
         local name, _ = strsplit(" ", msg)
         Guildbook.DEBUG("event", "CHAT_MSG_SYSTEM", string.format("%s joined a guild", name))
 
-        GuildbookUI.home:OnNewsFeedReceived(_, {
+        GuildbookUI.home:OnNewsFeedReceived(nil, {
             newsType = "playerJoinedGuild",
             text = string.format("%s has joined the guild", name)
         })
@@ -1423,7 +1423,7 @@ function Character:ScanTradeskillRecipes()
     if type(localeProf) ~= "string" then
 
         --we need this fontstring to exist before trying
-        if TradeskillFrameTitleText then
+        if TradeSkillFrameTitleText then
             localeProf = TradeSkillFrameTitleText:GetText()
         end
         
@@ -3256,7 +3256,7 @@ function Guildbook:PLAYER_ENTERING_WORLD(...)
     
             --if this is the initail login then say hello
             if isInitialLogin == true then
-                GuildbookUI.home:OnNewsFeedReceived(_, {
+                GuildbookUI.home:OnNewsFeedReceived(nil, {
                     newsType = "login",
                     text = string.format("%s has come online", UnitName("player"))
                 })
@@ -3688,6 +3688,7 @@ function Guildbook:GetCalendarEvents(start, duration)
     local events = {}
     local today = date('*t')
     local finish = (time(today) + (60*60*24*duration))
+    local guildName = Guildbook:GetGuildName()
     if GUILDBOOK_GLOBAL and GUILDBOOK_GLOBAL['Calendar'] and GUILDBOOK_GLOBAL['Calendar'][guildName] then
         for k, event in pairs(GUILDBOOK_GLOBAL['Calendar'][guildName]) do
             --local eventTimeStamp = time(event.date)
@@ -5232,7 +5233,7 @@ function Guildbook:SendGuildCalendarEvent(event)
     }
     self:Transmit(calendarEvent, 'GUILD', nil, 'NORMAL')
 
-    GuildbookUI.home:OnNewsFeedReceived(_, {
+    GuildbookUI.home:OnNewsFeedReceived(nil, {
         newsType = "calendarEventCreated",
         text = string.format("Calendar event %s created by %s", event.title, UnitName("player"))
     })
@@ -5263,7 +5264,7 @@ function Guildbook:OnGuildCalendarEventCreated(data, distribution, sender)
             table.insert(GUILDBOOK_GLOBAL['Calendar'][guildName], data.payload)
 
             -- when i redesign the calendar into a mixin callback fun bag i can (in theory) use th same callback/triggers but for now just need to add the news
-            GuildbookMixin:OnNewsFeedReceived(_, {
+            GuildbookMixin:OnNewsFeedReceived(nil, {
                 newsType = "calendarEventCreated",
                 text = string.format("Calendar event %s created by %s", data.payload.title, sender)
             })
@@ -5616,7 +5617,7 @@ function Guildbook:CHAT_MSG_GUILD(...)
         senderGUID = guid,
     })
 
-    GuildbookUI.home:OnNewsFeedReceived(_, {
+    GuildbookUI.home:OnNewsFeedReceived(nil, {
         newsType = "guildChat",
         text = string.format("%s [%s%s|r]: %s", date("%T"), Guildbook.Data.Class[character.Class].FontColour, sender, msg),
     })

--- a/Core.lua
+++ b/Core.lua
@@ -95,10 +95,10 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
 --slash commands
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-SLASH_GUILDBOOK1 = '/guildbook'
-SLASH_GUILDBOOK2 = '/gbk'
-SLASH_GUILDBOOK3 = '/gb'
-SlashCmdList['GUILDBOOK'] = function(msg)
+_G.SLASH_GUILDBOOK1 = '/guildbook'
+_G.SLASH_GUILDBOOK2 = '/gbk'
+_G.SLASH_GUILDBOOK3 = '/gb'
+_G.SlashCmdList['GUILDBOOK'] = function(msg)
     --print("["..msg.."]")
     if msg == 'open' then
         GuildbookUI:Show()

--- a/globals.lua
+++ b/globals.lua
@@ -1,0 +1,162 @@
+
+--[[
+
+globals.lua (FindGlobals), a useful script to find global variable access in 
+.lua files, placed in the public domain by Mikk in 2009. 
+
+HOW TO INVOKE:
+  luac -l MyFile.lua | lua globals.lua MyFile.lua
+or:
+  c:\path\to\luac.exe -l MyFile.lua | c:\path\to\lua.exe c:\path\to\globals.lua MyFile.lua
+
+Directives in the file:
+
+-- GLOBALS: SomeGlobal, SomeOtherGlobal
+  The script will never complain about these. There may be multiple lines of these anywhere in the file, taking effect globally (for now). There is no way to un-GLOBAL an already declared global.
+
+-- SETGLOBALFILE [ON/OFF]
+  Enable/disable SETGLOBAL checks in the global scope
+  Default: ON
+  
+-- SETGLOBALFUNC [ON/OFF]
+  Enable/disable SETGLOBAL checks in functions. This setting affects the whole file (for now)
+  Default: ON
+  
+-- GETGLOBALFILE [ON/OFF]
+  Default: OFF
+
+-- GETGLOBALFUNC [ON/OFF]
+  Default: ON
+  
+--]]
+
+local strmatch=string.match
+local strgmatch=string.gmatch
+local print=print
+local gsub = string.gsub
+local tonumber=tonumber
+local stdin=io.input()
+
+local source=assert(io.open(arg[1]))
+
+
+-- First we parse the source file
+
+local funcNames={}
+local GLOBALS={}
+local SETGLOBALfile = true
+local SETGLOBALfunc = true
+local GETGLOBALfile = false
+local GETGLOBALfunc = true
+
+local n=0
+
+while true do
+	local lin = source:read()
+	if not lin then break end
+	n=n+1
+
+	-- Lamely try to find all function headers and remember the line they were on. Yes, you can fool this. You can also shoot yourself in the foot. Either way it doesn't matter hugely, it's just to prettify the output.
+
+	local func = strmatch(lin, "%f[%a_][%a0-9_.:]+%s*=%s*function%s*%([^)]*") or  -- blah=function(...)
+		strmatch(lin, "%f[%a_]function%s*%([^)]*") or -- function(...)
+		strmatch(lin, "%f[%a_]function%s+[%a0-9_.:]+%s*%([^)]*")  -- function blah(...)
+	
+	if func then
+		func=func..")"
+		funcNames[n]=func
+	end
+	
+	if strmatch(lin, "^%s*%-%-") then
+		local args = strmatch(lin, "^%s*%-%-%s*GLOBALS:%s*(.*)")
+		if args then 
+			for name in strgmatch(args, "[%a0-9_]+") do
+				GLOBALS[name]=true
+			end
+		end
+
+		local args = strmatch(lin, "^%s*%-%-%s*SETGLOBALFILE%s+(%u+)")
+		if args=="ON" then 
+			SETGLOBALfile=true
+		elseif args=="OFF" then
+			SETGLOBALfile=false
+		end
+
+		local args = strmatch(lin, "^%s*%-%-%s*GETGLOBALFILE%s+(%u+)")
+		if args=="ON" then 
+			GETGLOBALfile=true
+		elseif args=="OFF" then
+			GETGLOBALfile=false
+		end
+		
+		local args = strmatch(lin, "^%s*%-%-%s*SETGLOBALFUNC%s+(%u+)")
+		if args=="ON" then 
+			SETGLOBALfunc=true
+		elseif args=="OFF" then
+			SETGLOBALfunc=false
+		end
+
+		local args = strmatch(lin, "^%s*%-%-%s*GETGLOBALFUNC%s+(%u+)")
+		if args=="ON" then 
+			GETGLOBALfunc=true
+		elseif args=="OFF" then
+			GETGLOBALfunc=false
+		end
+	end
+end
+
+-- Helper function that prints a line along with which function it is in. 
+
+local curfunc
+local lastfuncprinted
+
+local function printone(lin)
+	local globalName = strmatch(lin, "\t; (.+)%s*")
+	if globalName and GLOBALS[globalName] then
+		return
+	end
+	
+	if curfunc~=lastfuncprinted then
+		local from,to = strmatch(curfunc, "function <[^:]*:(%d+),(%d+)")
+		from=tonumber(from)
+		if from and funcNames[from] then
+			print(funcNames[from],strmatch(curfunc, "<.*"))
+		else
+			print(curfunc)
+		end
+		lastfuncprinted = curfunc
+	end
+	lin=gsub(lin, "%d+\t(%[%d+%])", "%1")	-- "23 [234]"  -> "[234]"   (strip the byte offset, we're not interested in it)
+	print(lin)
+end
+
+
+-- Loop the compiled output, looking for GETGLOBAL, SETGLOBAL, etc..
+
+local nSource=0
+local funcScope = false
+
+while true do
+	local lin = stdin:read()
+	if not lin then break end
+
+	if strmatch(lin,"^main <") then
+		curfunc=lin
+		funcScope = false
+	elseif strmatch(lin,"^function <") then
+		curfunc=lin
+		funcScope = true
+	elseif strmatch(lin,"SETGLOBAL\t") then
+		if funcScope and SETGLOBALfunc then
+			printone(lin)
+		elseif not funcScope and SETGLOBALfile then
+			printone(lin)
+		end
+	elseif strmatch(lin,"GETGLOBAL\t") then
+		if funcScope and GETGLOBALfunc then
+			printone(lin)
+		elseif not funcScope and GETGLOBALfile then
+			printone(lin)
+		end
+	end
+end


### PR DESCRIPTION
Typos in code suck. They are hard to spot, and result in random Lua errors.

One way to spot such errors is static analysis -- letting a program analyze your program. In Lua, a popular way to do this is [scanning for global variable accesses](https://www.wowace.com/projects/findglobals). A performant addon should practically never access the global environment, since doing so is slow as molasses. Therefore, any global variable access tends to be a mis-spelled variable name, copy/paste error or similar.

This PR's first two commits add the required boilerplates to the top of `Core.lua`, loading all the used Blizzard APIs into local variables instead. This is a free speed-up, and allows static analysis as described above. The third commit fixes a handful of existing typos caught in the process.