### PR TITLE
Tbc som

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -734,12 +734,12 @@ Tradeskills.TradeskillIDsToLocaleName = {
 	-- discovered this locale exists also maybe esAL ?
 	esES = {
         [164] = "Herrería",
-        [165] = "Peletería",
+        [165] = {"Peletería", "Marroquinería"},
         [171] = "Alquimia",
         [182] = "Herboristería",
         [185] = "Cocina",
         [186] = "Minería",
-        [197] = "Sastrería",
+        [197] = {"Sastrería", "Costura"},
         [202] = "Ingeniería",
         [333] = "Encantamiento",
         [356] = "Pesca",
@@ -829,13 +829,38 @@ Tradeskills.TradeskillIDsToLocaleName = {
 		[129] = "응급치료",
 	},
 }
+
+-- Invert the table so we can look up the ID by name(s)
+function tInvert(t)
+    local s = {}
+    for k, v in pairs(t) do
+        if type(v) == "table" then
+            for i, value in ipairs(v) do
+                s[value] = k
+            end
+        else
+            s[v] = k
+        end
+    end
+    return s
+end
+
 Tradeskills.TradeskillLocaleNameToID = tInvert(Tradeskills.TradeskillIDsToLocaleName[Tradeskills.CurrentLocale])
 
+-- returns true if the tradeskill is a valid tradeskill
 function Tradeskills:IsTradeskill(tradeskillName, tradeskillID)
     if type(tradeskillName) == "string" then
         for id, name in pairs(self.TradeskillIDsToLocaleName[GetLocale()]) do
-            if name == tradeskillName then
-                return true;
+            if type(name) == "table" then
+                for i, value in ipairs(name) do
+                    if value == tradeskillName then
+                        return true
+                    end
+                end
+            else
+                if name == tradeskillName then
+                    return true
+                end
             end
         end
     else
@@ -1727,7 +1752,6 @@ function Character:ScanTradeskillRecipes()
 
     --check everything is all good
     if type(localeProf) == "string" and type(currentLevel) == "number" and type(maxLevel) == "number" then
-
         englishProf = Tradeskills:GetEnglishNameFromTradeskillName(localeProf)
         if englishProf == false then
             Guildbook.DEBUG("characterMixin", "Character:ScanTradeskillRecipes", "englishProf not known")

--- a/Core.lua
+++ b/Core.lua
@@ -717,12 +717,12 @@ Tradeskills.TradeskillIDsToLocaleName = {
 	},
 	esMX = {
 		[164] = "Herrería",
-		[165] = "Peletería",
+        [165] = {"Peletería", "Marroquinería"},
 		[171] = "Alquimia",
-		[182] = "Herboristería",
+        [182] = {"Herboristería", "Botánica"},
 		[185] = "Cocina",
 		[186] = "Minería",
-		[197] = "Sastrería",
+        [197] = {"Sastrería", "Costura"},
 		[202] = "Ingeniería",
 		[333] = "Encantamiento",
 		[356] = "Pesca",
@@ -731,12 +731,12 @@ Tradeskills.TradeskillIDsToLocaleName = {
 		[773] = "Inscripción",
 		[129] = "Primeros auxilios",
 	},
-	-- discovered this locale exists also maybe esAL ?
-	esES = {
+    -- discovered this locale exists also maybe esAL ?
+    esES = {
         [164] = "Herrería",
         [165] = {"Peletería", "Marroquinería"},
         [171] = "Alquimia",
-        [182] = "Herboristería",
+        [182] = {"Herboristería", "Botánica"},
         [185] = "Cocina",
         [186] = "Minería",
         [197] = {"Sastrería", "Costura"},
@@ -746,7 +746,7 @@ Tradeskills.TradeskillIDsToLocaleName = {
         [393] = "Desuello",
         [755] = "Joyería",
         [773] = "Inscripción",
-		[129] = "Primeros auxilios",
+        [129] = "Primeros auxilios",
     },
 	ptBR = {
 		[164] = "Ferraria",

--- a/Templates.lua
+++ b/Templates.lua
@@ -122,9 +122,17 @@ function GuildbookListviewItemMixin:OnLoad()
     -- self.Text:SetFont([[Interface\Addons\Guildbook\Media\Fonts\Acme-Regular.ttf]], size+4, flags)
 end
 
+-- shows the item in the listview. If the table contains multiple tradeskill names, use the first one
 function GuildbookListviewItemMixin:SetItem(info)
     self.Icon:SetAtlas(info.Atlas)
-    self.Text:SetText(gb.Tradeskills.TradeskillIDsToLocaleName[GetLocale()][info.id])
+    local tradeskillName
+    local tradeskill = gb.Tradeskills.TradeskillIDsToLocaleName[GetLocale()][info.id]
+    if type(tradeskill) == "table" then
+        tradeskillName = tradeskill[1]
+    else
+        tradeskillName = tradeskill
+    end
+    self.Text:SetText(tradeskillName)
 end
 
 function GuildbookListviewItemMixin:OnMouseDown()


### PR DESCRIPTION
In the Spanish translation of the WoW Classic Era (or Vanilla rather) version, there is a problem with at least 3 professions in the game. These professions are leatherworking, tailoring and herbalism.
These professions have 2 possible texts throughout the game and are used arbitrarily. For example, in the character's stats section, one name appears, and yet in the recipes a different name appears, and in another place a different one, etc...
That is why I have modified the code to allow several names for the same profession. I have adapted all the code that is affected by this, so that the functionality that exists until now is maintained and this peculiarity can be taken into consideration.


Regarding the changes I have made:

- I have added to the esES and esMX locations a list in those professions containing the different strings used in-game for a profession.
- All the methods accessing or dealing with the location arrays have been modified so that they can work correctly with both strings and lists.


The above changes have been made to fix a bug that has existed since the first version of the addon. The bug happens when you are using the esES or esMX localization, when GuildBook tries to detect one of the three professions mentioned above. As there are two possible names for the same profession, it fails to correctly identify it and/or process its data. It detects it, but it did not finish processing its recipes and sharing them.